### PR TITLE
Allow any ruby version greater than 2.3

### DIFF
--- a/rubocop-teamcity-formatter.gemspec
+++ b/rubocop-teamcity-formatter.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'rubocop-teamcity-formatter'
-  s.version       = '0.0.2'
+  s.version       = '0.0.3'
   s.date          = '2016-11-23'
   s.summary       = 'Report RuboCop offences as TeamCity Service Messages'
   s.description   = 'Allows TeamCity builds to properly report RuboCop offences'
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.license       = 'MIT'
 
-  s.required_ruby_version = '~> 2.3'
+  s.required_ruby_version = '>= 2.3'
 
   s.add_development_dependency 'rake', '~> 12.3.3'
   s.add_development_dependency 'rspec', '~> 3.4'


### PR DESCRIPTION
changing the required ruby version to allow any projects using newer ruby version to still use this gem